### PR TITLE
add ellipses to the configuration

### DIFF
--- a/codegen/config_editor.rb
+++ b/codegen/config_editor.rb
@@ -314,6 +314,7 @@ latin_index = {
     {hex: "2020", row: 0, col: 10, label: "†"},
     {hex: "2021", row: 0, col: 14, label: "‡"},
     {hex: "2022", row: 5, col: 10, label: "•"},
+    {hex: "2026", row: 9, col: 12, label: "…"},
 
     # Unicode Currency Symbols block
     {hex: "20AC", row: 11, col: 13, label: "€"},


### PR DESCRIPTION
Just noticed that the ellipses is missing from the latin set, even though it exists in the font. I think this PR will cause this to be generated in the future. 